### PR TITLE
Fixed FileError when running first time on Windows.

### DIFF
--- a/easypypi/easypypi.py
+++ b/easypypi/easypypi.py
@@ -86,6 +86,14 @@ class Package(CleverDict):
         del self.x
         self.save()
         """
+
+        if not self.__class__.config_filepath.parent.exists():
+            """
+            Creates the parent folder for config_filepath to
+            prevent FileError when opening
+            """
+            self.__class__.config_filepath.parent.mkdir()
+
         with open(self.__class__.config_filepath, "w") as file:
             # CleverDict.get_aliases finds attributes created after __init__:
             fields_dict = {


### PR DESCRIPTION

I installed the package from PyPi and immediately got a FileError in the `%UserName%\AppData\Roaming\easyPyPi\` folder after the first popup where the package name is entered in the window, when running the `Package.save()` function. 
The Error occurred because the "easyPyPi" folder was not being created when running the 
```python
with open(self.__class__.config_filepath, "w") as file:
```
and writing the config_file in the save function. 

I added this to solve the problem. 

Best Regards
JayKayAce